### PR TITLE
Jsonable message

### DIFF
--- a/src/MS/Email/Parser/Address.php
+++ b/src/MS/Email/Parser/Address.php
@@ -1,11 +1,13 @@
 <?php
 
 namespace MS\Email\Parser;
+use JsonSerializable;
 
 /**
  * @author msmith
+ * @author sebastien monterisi <sebastienmonterisi@yahoo.fr>
  */
-class Address
+class Address implements JsonSerializable
 {
     protected $name;
 
@@ -46,6 +48,13 @@ class Address
     public function getName()
     {
         return $this->name;
+    }
+
+    public function jsonSerialize()
+    {
+        return ['name'=> $this->getName(),
+                'address' => $this->getAddress(),
+            ];
     }
 
 }

--- a/src/MS/Email/Parser/AddressCollection.php
+++ b/src/MS/Email/Parser/AddressCollection.php
@@ -1,16 +1,15 @@
 <?php
-/**
- * Created by PhpStorm.
- * User: msmith
- * Date: 12/13/13
- * Time: 9:32 PM
- */
 
 namespace MS\Email\Parser;
 
 use Doctrine\Common\Collections\ArrayCollection;
+use JsonSerializable;
 
-class AddressCollection extends ArrayCollection {
+/**
+ * @author msmith
+ * @author sebastien monterisi <sebastienmonterisi@yahoo.fr>
+ */
+class AddressCollection extends ArrayCollection implements JsonSerializable {
 
     public function __construct($addressesStr)
     {
@@ -26,6 +25,11 @@ class AddressCollection extends ArrayCollection {
         }
 
         parent::__construct($addresses);
+    }
+
+    public function jsonSerialize()
+    {
+        return $this->getValues();
     }
 
 }

--- a/src/MS/Email/Parser/Message.php
+++ b/src/MS/Email/Parser/Message.php
@@ -2,10 +2,13 @@
 
 namespace MS\Email\Parser;
 
+use JsonSerializable;
+
 /**
  * @author msmith
+ * @author sebastien monterisi <sebastienmonterisi@yahoo.fr>
  */
-class Message
+class Message implements JsonSerializable
 {
 
     protected $htmlBody;
@@ -88,6 +91,17 @@ class Message
     public function getCC()
     {
         return $this->cc;
+    }
+
+    public function jsonSerialize()
+    {
+        return [
+          'to' => $this->getTo(),  
+          'from' => $this->getFrom(),  
+          'subject' => $this->getSubject(),  
+          'html_body' => $this->getHtmlBody(),  
+          'text_body' => $this->getTextBody(),  
+        ];
     }
 
 }

--- a/src/MS/Email/Parser/Message.php
+++ b/src/MS/Email/Parser/Message.php
@@ -12,19 +12,12 @@ class Message implements JsonSerializable
 {
 
     protected $htmlBody;
-
     protected $textBody;
-
     protected $attachments = array();
-
     protected $to;
-
     protected $cc;
-
     protected $from;
-
     protected $subject;
-
     protected $date;
 
     public function __construct(Address $from, AddressCollection $to, AddressCollection $cc, $subject, $textBody, $htmlBody, $attachments = array(), $date)
@@ -96,11 +89,13 @@ class Message implements JsonSerializable
     public function jsonSerialize()
     {
         return [
-          'to' => $this->getTo(),  
-          'from' => $this->getFrom(),  
-          'subject' => $this->getSubject(),  
-          'html_body' => $this->getHtmlBody(),  
-          'text_body' => $this->getTextBody(),  
+            'date' => $this->getDate(),
+            'to' => $this->getTo(),
+            'cc' => $this->getCC(),
+            'from' => $this->getFrom(),
+            'subject' => $this->getSubject(),
+            'html_body' => $this->getHtmlBody(),
+            'text_body' => $this->getTextBody(),
         ];
     }
 

--- a/src/MS/Email/Parser/Part.php
+++ b/src/MS/Email/Parser/Part.php
@@ -2,10 +2,13 @@
 
 namespace MS\Email\Parser;
 
+use JsonSerializable;
+
 /**
  * @author msmith
+ * @author sebastien monterisi <sebastienmonterisi@yahoo.fr>
  */
-class Part
+class Part implements JsonSerializable
 {
     protected $type;
 
@@ -64,5 +67,14 @@ class Part
         return $this->type;
     }
 
+    public function jsonSerialize()
+    {
+        return [
+          'type'=>$this->getType(),
+          'disposition' => $this->getDisposition(),
+          'encoding' => $this->getEncoding(),
+          'content' => $this->getDecodedContent()
+        ];
+    }
 
 }

--- a/test/MS/Email/Parser/Test/AddressCollectionTest.php
+++ b/test/MS/Email/Parser/Test/AddressCollectionTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace MS\Email\Parser\Test;
+
+use MS\Email\Parser\AddressCollection;
+use MS\Email\Parser\Address;
+
+/**
+ * @author msmith
+ * @author sebastien monterisi <sebastienmonterisi@yahoo.fr>
+ */
+class AddressCollectionTest extends TestCase
+{    
+    public function testJsonSerializable()
+    {
+        // test data
+        $addresses = [];
+        $addresses[] = new Address('Dan Occhi <dan@example.com>');
+        $addresses[] = new Address('Michael Smith <sitecross@gmail.com>');
+        $addresses[] = new Address('Sébastien Monterisi <sebastienmonterisi@yahoo.fr>');
+        $addressCollection = new AddressCollection($addresses);
+
+        // expected data
+        // $this->prepareExpectation($addressCollection);
+        $expected = '[{"name":"Dan Occhi","address":"dan@example.com"},{"name":"Michael Smith","address":"sitecross@gmail.com"},{"name":"S\u00e9bastien Monterisi","address":"sebastienmonterisi@yahoo.fr"}]';
+        
+        $this->assertEquals($expected, json_encode($addressCollection));
+    }
+
+    /**
+     * use only to prepare expected data, in case Address serialization changes 
+     * @param AddressCollection $addresses
+     */
+    private function prepareExpectation(AddressCollection $addresses)
+    {
+        // starts with array bracket
+        $expected = '[';
+        foreach ($addresses as $address)
+        {
+            $expected .= json_encode($address).',';
+        }
+        // remove last ','
+        $expected = substr($expected, 0, -1);
+        // ends with array bracket
+        $expected .= ']';
+        
+        var_dump($expected);
+        exit(1);
+    }
+}

--- a/test/MS/Email/Parser/Test/AddressTest.php
+++ b/test/MS/Email/Parser/Test/AddressTest.php
@@ -6,6 +6,7 @@ use MS\Email\Parser\Address;
 
 /**
  * @author msmith
+ * @author sebastien monterisi <sebastienmonterisi@yahoo.fr>
  */
 class AddressTest extends TestCase
 {
@@ -26,6 +27,14 @@ class AddressTest extends TestCase
         $a = new Address('dan@example.com');
         $this->assertEquals('', $a->getName());
         $this->assertEquals('dan@example.com', $a->getAddress());
+    }
+    
+    public function testJsonSerializable()
+    {
+        $address = new Address('Dan Occhi <dan@example.com>');
+        $expected = '{"name":"Dan Occhi","address":"dan@example.com"}';
+        
+        $this->assertEquals($expected, json_encode($address));
     }
 
 }

--- a/test/MS/Email/Parser/Test/MessageTest.php
+++ b/test/MS/Email/Parser/Test/MessageTest.php
@@ -19,7 +19,7 @@ class MessageTest extends TestCase
 
         // expected data
 //        $this->prepareExpectation($message);
-        $expected = '{"to":[{"name":"","address":"atapi@astrotraker.com"}],"from":{"name":"Michael Smith","address":"example@textilemanagement.com"},"subject":"Fwd: test subject","html_body":"<html>\n  <head>\n\n    <meta http-equiv=\"content-type\" content=\"text\/html; charset=ISO-8859-1\">\n  <\/head>\n  <body bgcolor=\"#FFFFFF\" text=\"#000000\">\n    <br>\n      <br>\n      <pre>--\n\nThanks,\nMichael\n\n\n<\/pre>\n      <br>\n    <\/div>\n    <br>\n  <\/body>\n<\/html>","text_body":"\n\n--\n\nThanks,\nMichael\n"}';
+        $expected = '{"date":"Wed, 30 Jan 2013 16:18:32 -0600","to":[{"name":"","address":"atapi@astrotraker.com"}],"cc":[],"from":{"name":"Michael Smith","address":"example@textilemanagement.com"},"subject":"Fwd: test subject","html_body":"<html>\n  <head>\n\n    <meta http-equiv=\"content-type\" content=\"text\/html; charset=ISO-8859-1\">\n  <\/head>\n  <body bgcolor=\"#FFFFFF\" text=\"#000000\">\n    <br>\n      <br>\n      <pre>--\n\nThanks,\nMichael\n\n\n<\/pre>\n      <br>\n    <\/div>\n    <br>\n  <\/body>\n<\/html>","text_body":"\n\n--\n\nThanks,\nMichael\n"}';
 
         $this->assertEquals($expected, json_encode($message));
     }
@@ -32,7 +32,9 @@ class MessageTest extends TestCase
     {
         // starts with array bracket
         $expected_array = [];
+        $expected_array['date'] = ($message->getDate());
         $expected_array['to'] = ($message->getTo());
+        $expected_array['cc'] = ($message->getCC());
         $expected_array['from'] = ($message->getFrom());
         $expected_array['subject'] = ($message->getSubject());
         $expected_array['html_body'] = ($message->getHtmlBody());

--- a/test/MS/Email/Parser/Test/MessageTest.php
+++ b/test/MS/Email/Parser/Test/MessageTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace MS\Email\Parser\Test;
+
+use MS\Email\Parser\Parser;
+
+/**
+ * @author msmith
+ * @author sebastien monterisi <sebastienmonterisi@yahoo.fr>
+ */
+class MessageTest extends TestCase
+{
+    
+    
+    public function testJsonSerializable()
+    {
+//        $parser = ;
+        $message = (new Parser())->parse(file_get_contents(__DIR__ . '/files/thunderbird.txt'));
+
+        // expected data
+//        $this->prepareExpectation($message);
+        $expected = '{"to":[{"name":"","address":"atapi@astrotraker.com"}],"from":{"name":"Michael Smith","address":"example@textilemanagement.com"},"subject":"Fwd: test subject","html_body":"<html>\n  <head>\n\n    <meta http-equiv=\"content-type\" content=\"text\/html; charset=ISO-8859-1\">\n  <\/head>\n  <body bgcolor=\"#FFFFFF\" text=\"#000000\">\n    <br>\n      <br>\n      <pre>--\n\nThanks,\nMichael\n\n\n<\/pre>\n      <br>\n    <\/div>\n    <br>\n  <\/body>\n<\/html>","text_body":"\n\n--\n\nThanks,\nMichael\n"}';
+
+        $this->assertEquals($expected, json_encode($message));
+    }
+
+    /**
+     * use only to prepare expected data, in case Address serialization changes 
+     * @param AddressCollection $addresses
+     */
+    private function prepareExpectation(\MS\Email\Parser\Message $message)
+    {
+        // starts with array bracket
+        $expected_array = [];
+        $expected_array['to'] = ($message->getTo());
+        $expected_array['from'] = ($message->getFrom());
+        $expected_array['subject'] = ($message->getSubject());
+        $expected_array['html_body'] = ($message->getHtmlBody());
+        $expected_array['text_body'] = ($message->getTextBody());
+        
+        var_dump(json_encode($expected_array));
+        exit(1);
+    }
+}

--- a/test/MS/Email/Parser/Test/PartTest.php
+++ b/test/MS/Email/Parser/Test/PartTest.php
@@ -6,6 +6,7 @@ use MS\Email\Parser\Part;
 
 /**
  * @author msmith
+ * @author sebastien monterisi <sebastienmonterisi@yahoo.fr>
  */
 class PartTest extends TestCase
 {
@@ -30,4 +31,9 @@ class PartTest extends TestCase
         $p->getDecodedContent();
     }
 
+    public function testJsonSerializable()
+    {
+        $part = new Part(quoted_printable_encode('This is a test 5=4+1'), 'quoted-printable', 'image/jpg', 'inline');
+        $this->assertEquals('{"type":"image\/jpg","disposition":"inline","encoding":"quoted-printable","content":"This is a test 5=4+1"}', json_encode($part));
+    }
 }


### PR DESCRIPTION
Message can now be render in json.

``` php
$message = (new Parser())->parse( "<content>");
echo json_encode($message);
```

will now output something like 

``` json
{
"to":[
    {"name":"","address":"atapi@astrotraker.com"}
    ],
"from":{
    "name":"Michael Smith",
    "address":"example@textilemanagement.com"
    },
"subject":"Fwd: test subject",
"html_body":"<html>\n  <head>\n\n    <meta http-equiv=\"content-type\" content=\"text\/html; charset=ISO-8859-1\">\n  <\/head>\n  <body bgcolor=\"#FFFFFF\" text=\"#000000\">\n    <br>\n      <br>\n      <pre>--\n\nThanks,\nMichael\n\n\n<\/pre>\n      <br>\n    <\/div>\n    <br>\n  <\/body>\n<\/html>",
"text_body":"\n\n--\n\nThanks,\nMichael\n"
}
```
